### PR TITLE
Insert media query for About page

### DIFF
--- a/app/assets/stylesheets/about.scss
+++ b/app/assets/stylesheets/about.scss
@@ -1,3 +1,24 @@
+/* If too narrow (mobile phone portrait), then one bigger picture per row */
+/* Else if too wide (computer), then four bigger pictures per row */
+@media (max-width: 650px), (min-width: 801px) {
+  .about-thumbnail {
+    border-radius: 100%;
+    overflow: hidden;
+    height: 200px;
+    width: 200px;
+  }
+}
+
+/* If wide but not enough (mobile phone landscape), then four smaller pictures per row */
+@media (min-width: 651px) and (max-width: 800px) {
+  .about-thumbnail {
+    border-radius: 100%;
+    overflow: hidden;
+    height: 100px;
+    width: 100px;
+  }
+}
+
 a {
   outline: 0;
 }
@@ -9,13 +30,6 @@ a {
 .mcmember {
   color: black;
   margin-bottom: 25px;
-}
-
-.thumbnail {
-  border-radius: 100%;
-  overflow: hidden;
-  height: 200px;
-  width: 200px;
 }
 
 .mfp-content {

--- a/app/views/pages/about.html.erb
+++ b/app/views/pages/about.html.erb
@@ -43,7 +43,7 @@
       <a class="ajax-popup" href="/templates/about/<%= mc_member.name %>">
           <div class="medium-3 large-3 columns end">
             <div class="mcmember"><center>
-              <div class="thumbnail">
+              <div class="about-thumbnail">
                 <%= image_tag "about/"+mc_member.casualimg %>
               </div>
               <span class="bold"><%= mc_member.name %></span><br>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -152,7 +152,7 @@ Step 3: Profit",
   },
   {
     name: "Terence Chok",
-    position: "Deputy Student Relations Secretary",
+    position: "Director of Welfare",
     wingid: 1,
     wingrank: 1,
     cellrank: 0,


### PR DESCRIPTION
1. Resizes images in the page appropriately based on the dimensions of every device in Chrome device mode (responsive design mode)
2. (Miscellaneous but important) Correct a mistake in seeds.rb for Terence's position

Findings:
Without media query:
1. Pure CSS will require padding and margin manipulation (by percentage) on the pictures but our pictures have texts below them.
2. JavaScript still requires exact dimensions for both height and width.
