### PR TITLE
Order events by created_by in mc and home

### DIFF
--- a/app/controllers/mc/events_controller.rb
+++ b/app/controllers/mc/events_controller.rb
@@ -2,12 +2,12 @@ class Mc::EventsController < Mc::BaseController
 	before_action :set_event, only: [:show, :edit, :update, :destroy]
 
 	def index
-		@events = Event.all
+		@events = Event.order(created_at: :desc)
 		@featured_events = Event.where('featured')
 	end
 
 	def show
-		@events = Event.all.order('created_at desc')
+		@events = Event.order(created_at: :desc)
 	end
 
 	def new

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -4,7 +4,7 @@ class PagesController < ApplicationController
 	end
 
 	def home
-		@events = Event.all
+		@featured_events = Event.where(featured: true).limit(3)
 	end
 
 	def mcmem
@@ -17,7 +17,7 @@ class PagesController < ApplicationController
 	end
 
 	def event
-		@events = Event.all
+		@events = Event.order(created_at: :desc)
 		render 'events'
 	end
 
@@ -25,7 +25,7 @@ class PagesController < ApplicationController
 	end
 
 	def events
-		@events = Event.all
+		@events = Event.order(created_at: :desc)
 	end
 
 	def sponsors

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -56,7 +56,7 @@
   <div class="row">
     <%# loop through the upcoming (at most 3) events and create the partial for each. %>
     <% count = 0 %>
-    <% @events.each do |event| %>
+    <% @featured_events.each do |event| %>
         <% if event.featured && count < 3 %>
             <%= render partial: "event", locals: {event: event} %>
             <% count += 1 %>


### PR DESCRIPTION
fixes #188

- sorts events by created_by in desc
- filters featured events for home page in controller instead of in view